### PR TITLE
Fix measurement parsing from the default graph

### DIFF
--- a/src/cgmes2pgm_converter/components/branch/line.py
+++ b/src/cgmes2pgm_converter/components/branch/line.py
@@ -79,8 +79,8 @@ class LineBuilder(AbstractPgmComponentBuilder):
 
             $TOPO_ISLAND
             #?topoIsland cim:IdentifiedObject.name "Network";
-            #            cim:TopologicalIsland.TopologicalNodes ?_tn1;
-            #            cim:TopologicalIsland.TopologicalNodes ?_tn2.
+            #            cim:TopologicalIsland.TopologicalNodes ?tn1;
+            #            cim:TopologicalIsland.TopologicalNodes ?tn2.
 
             BIND(COALESCE(?_aclR, ?_eqbR, ?_srcR, "0.0") as ?r)
             BIND(COALESCE(?_aclX, ?_eqbX, ?_srcX, "0.0") as ?x)

--- a/src/cgmes2pgm_converter/components/branch/line.py
+++ b/src/cgmes2pgm_converter/components/branch/line.py
@@ -23,21 +23,21 @@ from ..component import AbstractPgmComponentBuilder
 class LineBuilder(AbstractPgmComponentBuilder):
     _query = """
         SELECT  ?line
-                (SAMPLE(?_name) as ?name)
-                (SAMPLE(?_bch) as ?bch)
-                (SAMPLE(?_gch) as ?gch)
-                (SAMPLE(?_length) as ?length)
-                (SAMPLE(?_r) as ?r)
-                (SAMPLE(?_x) as ?x)
-                (SAMPLE(?_tn1) as ?tn1)
-                (SAMPLE(?_tn2) as ?tn2)
-                (SAMPLE(?_nomv1) as ?nomv1)
-                (SAMPLE(?_nomv2) as ?nomv2)
-                (SAMPLE(?_status1) as ?status1)
-                (SAMPLE(?_status2) as ?status2)
-                (SAMPLE(?__type) as ?type)
-                (SAMPLE(?_term1) as ?term1)
-                (SAMPLE(?_term2) as ?term2)
+                ?name
+                ?bch
+                ?gch
+                ?length
+                ?r
+                ?x
+                ?tn1
+                ?tn2
+                ?nomv1
+                ?nomv2
+                ?status1
+                ?status2
+                ?type
+                ?term1
+                ?term2
         WHERE {
             VALUES ?_type {
                 cim:ACLineSegment
@@ -47,9 +47,9 @@ class LineBuilder(AbstractPgmComponentBuilder):
             ?line a ?_type;
                     $IN_SERVICE
                     # cim:Equipment.inService "true";
-                    cim:IdentifiedObject.name ?_name.
+                    cim:IdentifiedObject.name ?name.
 
-            BIND(STRAFTER(STR(?_type), "#") AS ?__type)
+            BIND(STRAFTER(STR(?_type), "#") AS ?type)
 
             OPTIONAL { ?line cim:ACLineSegment.r ?_aclR. }
             OPTIONAL { ?line cim:ACLineSegment.x ?_aclX. }
@@ -62,39 +62,37 @@ class LineBuilder(AbstractPgmComponentBuilder):
             OPTIONAL { ?line cim:SeriesCompensator.r ?_srcR. }
             OPTIONAL { ?line cim:SeriesCompensator.x ?_srcX. }
 
-            ?_term1 a cim:Terminal;
+            ?term1 a cim:Terminal;
                 cim:Terminal.ConductingEquipment ?line;
-                cim:Terminal.TopologicalNode ?_tn1;
+                cim:Terminal.TopologicalNode ?tn1;
                 cim:ACDCTerminal.sequenceNumber "1"; ## order Terminal/Node by sequence number
-                cim:ACDCTerminal.connected ?_status1.
+                cim:ACDCTerminal.connected ?status1.
 
-            ?_term2 a cim:Terminal;
+            ?term2 a cim:Terminal;
                       cim:Terminal.ConductingEquipment ?line;
-                      cim:Terminal.TopologicalNode ?_tn2;
+                      cim:Terminal.TopologicalNode ?tn2;
                       cim:ACDCTerminal.sequenceNumber "2";
-                      cim:ACDCTerminal.connected ?_status2.
+                      cim:ACDCTerminal.connected ?status2.
 
-            ?_tn1 cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?_nomv1.
-            ?_tn2 cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?_nomv2.
+            ?tn1 cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?nomv1.
+            ?tn2 cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?nomv2.
 
             $TOPO_ISLAND
             #?topoIsland cim:IdentifiedObject.name "Network";
             #            cim:TopologicalIsland.TopologicalNodes ?_tn1;
             #            cim:TopologicalIsland.TopologicalNodes ?_tn2.
 
-            BIND(COALESCE(?_aclR, ?_eqbR, ?_srcR, "0.0") as ?_r)
-            BIND(COALESCE(?_aclX, ?_eqbX, ?_srcX, "0.0") as ?_x)
-            BIND(COALESCE(?_aclBch, "0.0") as ?_bch)
-            BIND(COALESCE(?_aclGch, "0.0") as ?_gch)
+            BIND(COALESCE(?_aclR, ?_eqbR, ?_srcR, "0.0") as ?r)
+            BIND(COALESCE(?_aclX, ?_eqbX, ?_srcX, "0.0") as ?x)
+            BIND(COALESCE(?_aclBch, "0.0") as ?bch)
+            BIND(COALESCE(?_aclGch, "0.0") as ?gch)
 
-            FILTER(?_tn1 != ?_tn2)
-            FILTER(?_status1 = "true" &&  ?_status2 = "true")
+            FILTER(?tn1 != ?tn2)
+            FILTER(?status1 = "true" &&  ?status2 = "true")
 
             $NOMV_FILTER
-            #FILTER(?_nomv1 = ?_nomv2)
+            #FILTER(?nomv1 = ?nomv2)
         }
-
-        GROUP BY ?line
         ORDER BY ?line
     """
 
@@ -114,8 +112,8 @@ class LineBuilder(AbstractPgmComponentBuilder):
     def build_from_cgmes(self, _) -> tuple[np.ndarray, dict | None]:
         args = {
             "$IN_SERVICE": self._in_service(),
-            "$TOPO_ISLAND": self._at_topo_island_node("?_tn1", "?_tn2"),
-            "$NOMV_FILTER": "FILTER(?_nomv1 = ?_nomv2)",  # <- filter for same voltage levels
+            "$TOPO_ISLAND": self._at_topo_island_node("?tn1", "?tn2"),
+            "$NOMV_FILTER": "FILTER(?nomv1 = ?nomv2)",  # <- filter for same voltage levels
         }
         q = self._replace(self._query, args)
         res = self._source.query(q)

--- a/src/cgmes2pgm_converter/components/measurement/power_sensor.py
+++ b/src/cgmes2pgm_converter/components/measurement/power_sensor.py
@@ -109,30 +109,34 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
             ?term
             ?value
             ?sigma
+            ?acc
             ?name
             ?meas
             ?pfi
         WHERE {
             # "ThreePhaseActivePower" or "ThreePhaseReactivePower"
             ?meas cim:Measurement.measurementType $MEASUREMENT_TYPE;
-                        cim:IdentifiedObject.name ?name;
-                        cim:Measurement.Terminal ?term.
+                  cim:IdentifiedObject.name ?name;
+                  cim:Measurement.Terminal ?term.
 
             OPTIONAL {
-                ?meas cim:Analog.positiveFlowIn ?pfi.
+                ?meas cim:Analog.positiveFlowIn ?_pfi.
             }
+            BIND(IF(BOUND(?_pfi), ?_pfi, "false") AS ?pfi)
 
             ?_measVal_scada cim:AnalogValue.Analog ?meas;
-                            cim:MeasurementValue.MeasurementValueSource/cim:IdentifiedObject.name "SCADA";
                             cim:AnalogValue.value ?value.
 
             OPTIONAL {
-                ?_measVal_est cim:AnalogValue.Analog ?meas;
-                              cim:MeasurementValue.sensorAccuracy ?sigma.
+                ?_measVal_scada cim:MeasurementValue.sensorAccuracy ?acc.
+            }
+
+            OPTIONAL {
+                ?_measVal_scada cim:MeasurementValue.sensorSigma ?sigma.
             }
 
             ?term cim:Terminal.TopologicalNode ?tn;
-                cim:Terminal.ConductingEquipment ?eq.
+                  cim:Terminal.ConductingEquipment ?eq.
 
             ?tn cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?nomv.
 

--- a/src/cgmes2pgm_converter/components/measurement/power_sensor.py
+++ b/src/cgmes2pgm_converter/components/measurement/power_sensor.py
@@ -236,7 +236,7 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
         res_p = self._source.query(q_p)
 
         # Invert Measurement if "positiveFlowIn" is set to true
-        res_p["value"] = res_p["value"].where(res_p["pfi"], res_p["value"] * -1)
+        res_p["value"] = res_p["value"].where(~res_p["pfi"], res_p["value"] * -1)
 
         # Read reactive power measurements
         args["$MEASUREMENT_TYPE"] = '"ThreePhaseReactivePower"'
@@ -244,7 +244,7 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
         res_q = self._source.query(q_q)
 
         # Invert Measurement if "positiveFlowIn" is set to true
-        res_q["value"] = res_q["value"].where(res_q["pfi"], res_q["value"] * -1)
+        res_q["value"] = res_q["value"].where(~res_q["pfi"], res_q["value"] * -1)
 
         meas_by_term = {}
         self._join_measurements_by_terminal(

--- a/src/cgmes2pgm_converter/components/measurement/power_sensor.py
+++ b/src/cgmes2pgm_converter/components/measurement/power_sensor.py
@@ -39,11 +39,7 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
             (SAMPLE(?_eq) as ?eq)
             (SAMPLE(?_tn) as ?tn)
             ?term
-            (SAMPLE(?_max_p) as ?max_p)
-            (SAMPLE(?_min_p) as ?min_p)
             (SAMPLE(?_p) as ?p)
-            (SAMPLE(?_max_q) as ?max_q)
-            (SAMPLE(?_min_q) as ?min_q)
             (SAMPLE(?_q) as ?q)
             (SAMPLE(?_acc_p) as ?acc_p)
             (SAMPLE(?_acc_q) as ?acc_q)
@@ -58,8 +54,6 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
             ?_meas_p cim:Measurement.measurementType ?_type_p;
                     cim:IdentifiedObject.name ?_name_p;
                     cim:Measurement.PowerSystemResource ?_eq;
-                    cim:Analog.maxValue ?_max_p;
-                    cim:Analog.minValue ?_min_p;
                     cim:Measurement.Terminal ?term.
 
             ?_measVal_p cim:AnalogValue.Analog ?_meas_p.
@@ -78,8 +72,6 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
             ?_meas_q cim:Measurement.measurementType ?_type_q;
                     cim:IdentifiedObject.name ?_name_q;
                     cim:Measurement.PowerSystemResource ?_eq;
-                    cim:Analog.maxValue ?_max_q;
-                    cim:Analog.minValue ?_min_q;
                     cim:Measurement.Terminal ?term.
 
     		?_meas_val_q cim:AnalogValue.Analog ?_meas_q.
@@ -122,7 +114,7 @@ class SymPowerBuilder(AbstractPgmComponentBuilder):
             OPTIONAL {
                 ?meas cim:Analog.positiveFlowIn ?_pfi.
             }
-            BIND(IF(BOUND(?_pfi), ?_pfi, "false") AS ?pfi)
+            BIND(COALESCE(?_pfi, "false") AS ?pfi)
 
             ?_measVal_scada cim:AnalogValue.Analog ?meas;
                             cim:AnalogValue.value ?value.

--- a/src/cgmes2pgm_converter/components/measurement/voltage_sensor.py
+++ b/src/cgmes2pgm_converter/components/measurement/voltage_sensor.py
@@ -46,7 +46,7 @@ class SymVoltageBuilder(AbstractPgmComponentBuilder):
                 OPTIONAL { ?measVal_v cim:MeasurementValue.sensorSigma ?sigma_u. }
 
             }
-            FILTER(?type_u = "Voltage")
+            VALUES ?type_u { "Voltage" "LineToLineVoltage" }
 
             ?term cim:Terminal.TopologicalNode ?tn.
 
@@ -64,25 +64,22 @@ class SymVoltageBuilder(AbstractPgmComponentBuilder):
     """
 
     _query_meas_in_default = """
-        SELECT ?eq ?tn ?term ?u ?sigma_u ?name ?meas_u ?nom_u
+        SELECT ?eq ?tn ?term ?max_u ?min_u ?u ?nom_u ?acc_u ?sigma_u ?name ?meas_u
         WHERE {
-            ?meas_u cim:Measurement.measurementType "LineToLineVoltage";
-                  cim:IdentifiedObject.name ?name;
-                  cim:Measurement.PowerSystemResource ?eq;
-                  cim:Measurement.Terminal ?term.
+            ?meas_u cim:Measurement.measurementType ?type_u;
+                    cim:IdentifiedObject.name ?name;
+                    cim:Measurement.PowerSystemResource ?eq;
+                    cim:Measurement.Terminal ?term.
 
+            ?measVal_v cim:AnalogValue.Analog ?meas_u;
+            OPTIONAL { ?measVal_v cim:MeasurementValue.sensorAccuracy ?acc_u. }
+            OPTIONAL { ?measVal_v cim:MeasurementValue.sensorSigma ?sigma_u. }
 
-            ?_measVal_scada cim:AnalogValue.Analog ?meas_u;
-                            cim:MeasurementValue.MeasurementValueSource/cim:IdentifiedObject.name "SCADA";
-                            cim:AnalogValue.value ?u.
+            VALUES ?type_u { "Voltage" "LineToLineVoltage" }
 
-            OPTIONAL {
-                ?_measVal_est cim:AnalogValue.Analog ?meas_u;
-                              cim:MeasurementValue.sensorAccuracy ?sigma_u.
-            }
+            ?term cim:Terminal.TopologicalNode ?tn.
 
-            ?term cim:Terminal.TopologicalNode ?tn;
-                  cim:Terminal.ConductingEquipment ?eq.
+            ?measVal_v cim:AnalogValue.value ?u.
 
             ?tn cim:TopologicalNode.BaseVoltage/cim:BaseVoltage.nominalVoltage ?nom_u.
 

--- a/src/cgmes2pgm_converter/components/measurement/voltage_sensor.py
+++ b/src/cgmes2pgm_converter/components/measurement/voltage_sensor.py
@@ -31,14 +31,11 @@ from ..component import AbstractPgmComponentBuilder
 class SymVoltageBuilder(AbstractPgmComponentBuilder):
 
     _query_meas_in_graph = """
-        SELECT ?eq ?tn ?term ?max_u ?min_u ?u ?nom_u ?acc_u ?sigma_u ?name ?meas_u
+        SELECT ?tn ?term ?u ?nom_u ?acc_u ?sigma_u ?name ?meas_u
         WHERE {
             GRAPH <$OP_GRAPH> {
                 ?meas_u cim:Measurement.measurementType ?type_u;
                         cim:IdentifiedObject.name ?name;
-                        cim:Measurement.PowerSystemResource ?eq;
-                        cim:Analog.maxValue ?max_u;
-                        cim:Analog.minValue ?min_u;
                         cim:Measurement.Terminal ?term.
 
                 ?measVal_v cim:AnalogValue.Analog ?meas_u;
@@ -64,11 +61,10 @@ class SymVoltageBuilder(AbstractPgmComponentBuilder):
     """
 
     _query_meas_in_default = """
-        SELECT ?eq ?tn ?term ?max_u ?min_u ?u ?nom_u ?acc_u ?sigma_u ?name ?meas_u
+        SELECT ?tn ?term ?u ?nom_u ?acc_u ?sigma_u ?name ?meas_u
         WHERE {
             ?meas_u cim:Measurement.measurementType ?type_u;
                     cim:IdentifiedObject.name ?name;
-                    cim:Measurement.PowerSystemResource ?eq;
                     cim:Measurement.Terminal ?term.
 
             ?measVal_v cim:AnalogValue.Analog ?meas_u;


### PR DESCRIPTION
# Changes proposed in this PR

- Fix different results if measurements are in the default graph instead of a named graph
- Fix wrong use of `Analog.positiveFlowIn` resulting in negated measurements
- simplify queries for line and link